### PR TITLE
Allow favicon to bypass auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ the same variables you already use in `role_iptvservice`.
 - `role_iptvservice__firewall_command`, `role_iptvservice__firewall_local_ip`, `role_iptvservice__proxy_start_port`
 - `role_iptvservice__known_ips` (not used by default)
 - `role_iptvservice__credentials` (exact shape you posted)
+- `role_iptvservice__favicon_root` (directory containing `favicon.ico`)
 
 ## Example play
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,10 @@ role_iptvservice__python_packages:
 
 role_iptvservice__oos_url: https://yourwebsite.com/out_of_service.ts
 
+# Directory that holds static files served directly by nginx
+# The favicon is expected at <favicon_root>/favicon.ico
+role_iptvservice__favicon_root: "/var/www/html/{{ (role_iptvservice__iptv_hostname | first) | trim }}/iptvservice"
+
 
 role_iptvservice__kill_mode: false
 role_iptvservice__quarantine_path: "{{ role_iptvservice__auth_root }}/quarantine.json"

--- a/templates/nginx-site.conf.j2
+++ b/templates/nginx-site.conf.j2
@@ -71,6 +71,14 @@ server {
         return 302 {{ role_iptvservice__oos_url }};
     }
 
+    # ---------- Static favicon without auth ----------
+    location = /favicon.ico {
+        auth_request off;
+        root {{ role_iptvservice__favicon_root }};
+        access_log off;
+        log_not_found off;
+    }
+
     # ---------- Internal auth endpoint ----------
     location = /_auth {
         internal;


### PR DESCRIPTION
## Summary
- Serve favicon.ico without triggering auth
- Make favicon location configurable via `role_iptvservice__favicon_root`

## Testing
- `yamllint defaults/main.yml` *(fails: command not found)*
- `ansible-lint templates/nginx-site.conf.j2` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f4a104a0832ea80a2ce797d1a9ec