### PR TITLE
Update backend connection counts from upstream checks

### DIFF
--- a/tasks/upstream_accounts.yml
+++ b/tasks/upstream_accounts.yml
@@ -91,6 +91,68 @@
   loop_control:
     label: "FAIL {{ item.account }}"
 
+# Update backends.json and status.json with latest connection counts
+- name: Upstream Accounts | Load current backends.json
+  ansible.builtin.slurp:
+    src: "{{ role_iptvservice__auth_root | trim }}/backends.json"
+  register: __backends_raw
+  when: (__successful_upstreams | length) > 0
+
+- name: Upstream Accounts | Merge connection info into backends
+  ansible.builtin.set_fact:
+    __backends_updated: >-
+      {%- set current = (__backends_raw.content | b64decode | from_json) | default([], true) -%}
+      {%- set out = [] -%}
+      {%- for be in current -%}
+        {%- set match = (__successful_upstreams | selectattr('account','equalto', be.account) | first) -%}
+        {%- if match -%}
+          {%- set _ = out.append(
+                be | combine({
+                    'active_cons': match.active_cons,
+                    'max_connections': match.max_connections,
+                    'active': match.active_cons
+                })
+            ) -%}
+        {%- else -%}
+          {%- set _ = out.append(be) -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{ out }}
+  when: (__successful_upstreams | length) > 0
+
+- name: Upstream Accounts | Save updated backends.json
+  ansible.builtin.copy:
+    dest: "{{ role_iptvservice__auth_root | trim }}/backends.json"
+    content: "{{ __backends_updated | to_nice_json }}"
+    owner: "{{ role_iptvservice__auth_user }}"
+    group: "{{ role_iptvservice__auth_group }}"
+    mode: '0640'
+  when: (__successful_upstreams | length) > 0
+  notify: Restart iptv-auth
+
+- name: Upstream Accounts | Build status.json data
+  ansible.builtin.set_fact:
+    __status_data: >-
+      {%- set rows = [] -%}
+      {%- for s in __successful_upstreams -%}
+        {%- set _ = rows.append({
+          'account': s.account,
+          'active': s.active_cons,
+          'max_connections': s.max_connections
+        }) -%}
+      {%- endfor -%}
+      {{ {'upstreams': rows} }}
+  when: (__successful_upstreams | length) > 0
+
+- name: Upstream Accounts | Write status.json
+  ansible.builtin.copy:
+    dest: "{{ role_iptvservice__auth_root | trim }}/status.json"
+    content: "{{ __status_data | to_nice_json }}"
+    owner: "{{ role_iptvservice__auth_user }}"
+    group: "{{ role_iptvservice__auth_group }}"
+    mode: '0640'
+  when: (__successful_upstreams | length) > 0
+
 # ---------- Kill mode pipeline ----------
 - name: Upstream Accounts | Build path to backends.json
   ansible.builtin.set_fact:

--- a/tasks/upstream_accounts.yml
+++ b/tasks/upstream_accounts.yml
@@ -106,15 +106,20 @@
       {%- for be in current -%}
         {%- set match = (__successful_upstreams | selectattr('account','equalto', be.account) | first) -%}
         {%- if match -%}
-          {%- set _ = out.append(
-                be | combine({
+          {%- set merged = be | combine({
                     'active_cons': match.active_cons,
-                    'max_connections': match.max_connections,
-                    'active': match.active_cons
-                })
-            ) -%}
+                    'max_connections': match.max_connections
+                }) -%}
+          {%- set cleaned = merged | dict2items
+                                   | rejectattr('key', 'equalto', 'active')
+                                   | items2dict -%}
+          {%- set _ = out.append(cleaned) -%}
         {%- else -%}
-          {%- set _ = out.append(be) -%}
+          {%- set _ = out.append(
+                be | dict2items
+                   | rejectattr('key', 'equalto', 'active')
+                   | items2dict
+            ) -%}
         {%- endif -%}
       {%- endfor -%}
       {{ out }}

--- a/templates/app.py.j2
+++ b/templates/app.py.j2
@@ -163,7 +163,6 @@ def pick_backend_for_user(username: str) -> Optional[Dict[str, Any]]:
                 if not status_by_account:
                     cur_active = next((cur for b, cur, _, _ in scores if b is choice), 0) + 1
                     choice["active_cons"] = cur_active
-                    choice["active"] = cur_active
                     f.seek(0)
                     json.dump(BACKENDS, f, indent=2)
                     f.truncate()


### PR DESCRIPTION
## Summary
- propagate active and max connection data from upstream checks into backends.json
- write a status.json used by the auth app to avoid stale connection counts

## Testing
- `ansible-lint tasks/upstream_accounts.yml` *(fails: command not found)*
- `pip install ansible-lint` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5be1b31c832e85d1344f059a87e9